### PR TITLE
Add train_ratio in config.yml to generate train data without valid directory

### DIFF
--- a/util/sample_config.yml
+++ b/util/sample_config.yml
@@ -7,6 +7,7 @@ common:
 
 # train, validation and test RecordIO data generation settings
 data:
+  train_ratio: 1
   quality: 100
   shuffle: 1
   center_crop: 0


### PR DESCRIPTION
`gen_train.sh` respects data.train_ratio on config.yml but `setup.sh` do not generate the config. We should add it to guide how to configure the ratio.